### PR TITLE
Fix syntax deprecated in PHP 7.4

### DIFF
--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -51,7 +51,7 @@ class Json extends FileLoaderAbstract
     {
         return (
             !empty($string) &&
-            ($string{0} === '[' || $string{0} === '{')
+            ($string[0] === '[' || $string[0] === '{')
         );
     }
 


### PR DESCRIPTION
replace `{}` string character index with `[]`