### PR TITLE
Fix PHP 8.4 deprecation warnings for implicit nullable parameters

### DIFF
--- a/.github/workflows/pr_phpunit.yml
+++ b/.github/workflows/pr_phpunit.yml
@@ -20,7 +20,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: none
       - name: Cache PHP dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4
         with:
           path: LiveAgent/server/vendor
           key: ${{ runner.OS }}-composer_dependencies-${{ hashFiles('**/composer.lock') }}
@@ -28,7 +28,7 @@ jobs:
       - name: Install Composer dependencies
         run: composer install
       - name: Cache PHP Lint
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4
         with:
           path: LiveAgent/server/.phplint-cache
           key: PHPLint-${{ runner.os }}-${ github.sha }}

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -60,7 +60,7 @@ class ConfigLoader extends DelegatingLoader
      *
      * @return array Array of config options
      */
-    public function load(mixed $resource, string $type = null): mixed
+    public function load(mixed $resource, ?string $type = null): mixed
     {
         return parent::load($resource);
     }

--- a/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
@@ -102,7 +102,7 @@ class ExtraOptionsResolver
      * @param  ClassLoader|null $classLoader Optional class loader if you want to use custom
      * handlers for some of the extra options
      */
-    protected function configureOptions(OptionsResolver $resolver, ClassLoader $classLoader = null)
+    protected function configureOptions(OptionsResolver $resolver, ?ClassLoader $classLoader = null)
     {
         foreach ($this->params as $name) {
             if ($this->reflected->hasMethod($name)) {
@@ -136,7 +136,7 @@ class ExtraOptionsResolver
      *
      * @return array Array of resolved options
      */
-    public function resolve($options, ClassLoader $classLoader = null)
+    public function resolve($options, ?ClassLoader $classLoader = null)
     {
         $hashKey = self::generateParamsHashKey($this->params);
 

--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -32,7 +32,7 @@ class Json extends FileLoaderAbstract
      *
      * @return array Array containing data from the parsed JSON string or file
      */
-    public function load($resource, string $type = null)
+    public function load($resource, ?string $type = null)
     {
         return json_decode($this->readFrom($resource), true);
     }
@@ -59,11 +59,11 @@ class Json extends FileLoaderAbstract
      * Return whether or not the passed in resource is supported by this loader
      *
      * @param  string $resource Plain string or filepath
-     * @param  string $type Not used
+     * @param  string|null $type Not used
      *
      * @return boolean Whether or not the passed in resource is supported by this loader
      */
-    public function supports($resource, string $type = null)
+    public function supports($resource, ?string $type = null)
     {
         if (is_string($resource)) {
             if ($this->isFile($resource)) {

--- a/src/Config/Loader/FileLoader/PhpArray.php
+++ b/src/Config/Loader/FileLoader/PhpArray.php
@@ -31,7 +31,7 @@ class PhpArray extends FileLoaderAbstract
      *
      * @return array Array containing data from the PHP file
      */
-    public function load($resource, string $type = null)
+    public function load($resource, ?string $type = null)
     {
         $config = include $resource;
 
@@ -50,11 +50,11 @@ class PhpArray extends FileLoaderAbstract
      * will be thrown when it is loaded if that is not the case.
      *
      * @param  string $resource Filepath
-     * @param  string $type Not used
+     * @param  string|null $type Not used
      *
      * @return boolean Whether or not the passed in resource is supported by this loader
      */
-    public function supports($resource, string $type = null)
+    public function supports($resource, ?string $type = null)
     {
         return $this->isFile($resource) && $this->validateExtension($resource);
     }

--- a/src/Config/Loader/FileLoader/Yaml.php
+++ b/src/Config/Loader/FileLoader/Yaml.php
@@ -37,7 +37,7 @@ class Yaml extends FileLoaderAbstract
      *
      * @return array Array containing data from the parse Yaml string or file
      */
-    public function load($resource, string $type = null)
+    public function load($resource, ?string $type = null)
     {
         return YamlParser::parse($this->readFrom($resource));
     }
@@ -47,11 +47,11 @@ class Yaml extends FileLoaderAbstract
      * /!\ This does not validate Yaml content. The parser will raise an exception in that case
      *
      * @param  string $resource Plain string or filepath
-     * @param  string $type Not used
+     * @param  string|null $type Not used
      *
      * @return boolean Whether or not the passed in resrouce is supported by this loader
      */
-    public function supports($resource, string $type = null)
+    public function supports($resource, ?string $type = null)
     {
         if (!is_string($resource)) {
             return false;

--- a/src/Config/Loader/PhpArray.php
+++ b/src/Config/Loader/PhpArray.php
@@ -28,7 +28,7 @@ class PhpArray extends Loader
      *
      * @return array The passed in array
      */
-    public function load($array, string $type = null)
+    public function load($array, ?string $type = null)
     {
         return $array;
     }
@@ -41,7 +41,7 @@ class PhpArray extends Loader
      *
      * @return boolean Whether or not the passed in resource is supported by this loader
      */
-    public function supports($resource, string $type = null)
+    public function supports($resource, ?string $type = null)
     {
         return is_array($resource);
     }

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -11,10 +11,9 @@
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Cascade\Tests\Fixtures;
-use FileLoaderAbstractMockClass;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use RuntimeException;
 
 /**
@@ -26,7 +25,7 @@ class FileLoaderAbstractTest extends TestCase
 {
     /**
      * Mock of extending Cascade\Config\Loader\FileLoader\FileLoaderAbstract
-     * @var PHPUnit_Framework_MockObject_MockObject
+     * @var MockObject
      */
     protected $mock = null;
 
@@ -40,12 +39,12 @@ class FileLoaderAbstractTest extends TestCase
 
         $this->mock = $this->getMockForAbstractClass(
             'Cascade\Config\Loader\FileLoader\FileLoaderAbstract',
-            array($fileLocatorMock),
-            'FileLoaderAbstractMockClass' // mock class name
+            array($fileLocatorMock)
         );
 
         // Setting valid extensions for tests
-        FileLoaderAbstractMockClass::$validExtensions = array('test', 'php');
+        $mockClass = get_class($this->mock);
+        $mockClass::$validExtensions = ['test', 'php'];
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Explicitly declared nullable parameters.
Bumped `actions/cache` to v4 in workflow.
Updated test setup in `FileLoaderAbstractTest`