### PR TITLE
Allow symfony ^7|^8, drop pre-PHP-8 dep constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": "^8.4",
-        "symfony/config": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0" ,
-        "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/serializer": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^8.0",
-        "symfony/yaml": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^8.0",
-        "monolog/monolog": "^1.13 || ^2.0 || ^3.0"
+        "symfony/config": "^6.0 || ^7.0 || ^8.0",
+        "symfony/options-resolver": "^6.0 || ^7.0 || ^8.0",
+        "symfony/serializer": "^6.0 || ^7.0 || ^8.0",
+        "symfony/yaml": "^6.0 || ^7.0 || ^8.0",
+        "monolog/monolog": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -32,7 +32,7 @@ class Json extends FileLoaderAbstract
      *
      * @return array Array containing data from the parsed JSON string or file
      */
-    public function load($resource, ?string $type = null)
+    public function load(mixed $resource, ?string $type = null): mixed
     {
         return json_decode($this->readFrom($resource), true);
     }
@@ -63,7 +63,7 @@ class Json extends FileLoaderAbstract
      *
      * @return boolean Whether or not the passed in resource is supported by this loader
      */
-    public function supports($resource, ?string $type = null)
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         if (is_string($resource)) {
             if ($this->isFile($resource)) {

--- a/src/Config/Loader/FileLoader/PhpArray.php
+++ b/src/Config/Loader/FileLoader/PhpArray.php
@@ -31,7 +31,7 @@ class PhpArray extends FileLoaderAbstract
      *
      * @return array Array containing data from the PHP file
      */
-    public function load($resource, ?string $type = null)
+    public function load(mixed $resource, ?string $type = null): mixed
     {
         $config = include $resource;
 
@@ -54,7 +54,7 @@ class PhpArray extends FileLoaderAbstract
      *
      * @return boolean Whether or not the passed in resource is supported by this loader
      */
-    public function supports($resource, ?string $type = null)
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return $this->isFile($resource) && $this->validateExtension($resource);
     }

--- a/src/Config/Loader/FileLoader/Yaml.php
+++ b/src/Config/Loader/FileLoader/Yaml.php
@@ -37,7 +37,7 @@ class Yaml extends FileLoaderAbstract
      *
      * @return array Array containing data from the parse Yaml string or file
      */
-    public function load($resource, ?string $type = null)
+    public function load(mixed $resource, ?string $type = null): mixed
     {
         return YamlParser::parse($this->readFrom($resource));
     }
@@ -51,7 +51,7 @@ class Yaml extends FileLoaderAbstract
      *
      * @return boolean Whether or not the passed in resrouce is supported by this loader
      */
-    public function supports($resource, ?string $type = null)
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         if (!is_string($resource)) {
             return false;

--- a/src/Config/Loader/PhpArray.php
+++ b/src/Config/Loader/PhpArray.php
@@ -28,7 +28,7 @@ class PhpArray extends Loader
      *
      * @return array The passed in array
      */
-    public function load($array, ?string $type = null)
+    public function load(mixed $array, ?string $type = null): mixed
     {
         return $array;
     }
@@ -41,7 +41,7 @@ class PhpArray extends Loader
      *
      * @return boolean Whether or not the passed in resource is supported by this loader
      */
-    public function supports($resource, ?string $type = null)
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return is_array($resource);
     }


### PR DESCRIPTION
## Summary
- Widen `symfony/config`, `symfony/options-resolver`, `symfony/serializer`, `symfony/yaml` to permit `^7.0` and `^8.0`.
- Drop dead `^2.7 || ^3.0 || ^4.0 || ^5.0` constraints (and `monolog/monolog ^1.13 || ^2.0`) — the package already requires `php: ^8.4`, and those older majors target PHP 5/7 and cannot run on 8.4.
- Add `mixed` / `bool` return types to `load()`/`supports()` in the custom config loaders so they remain LSP-compatible with `Symfony\Component\Config\Loader\LoaderInterface`, which gained explicit return types in `symfony/config ^7.0`.

Without the type-declaration fix, bumping `symfony/config` to ^7/^8 produces a fatal error on PHP 8.4:
> `Declaration of Cascade\Config\Loader\PhpArray::load(...) must be compatible with Symfony\Component\Config\Loader\LoaderInterface::load(mixed $resource, ?string $type = null): mixed`

Supersedes #21 (which only widened `options-resolver` to ^8.0).

## Test plan
- [x] `phpunit` passes locally on PHP 8.4 against installed deps: `symfony/config 8.0.10`, `symfony/yaml 8.0.10`, `symfony/serializer 8.0.10`, `symfony/options-resolver 8.0.8`, `monolog/monolog 3.10.0` — 97 tests, 139 assertions, OK.
- [x] CI green on `php_tests (8.4)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)