### PR TITLE
Allow phpunit ^11 || ^12, migrate tests to attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
         "squizlabs/php_codesniffer": "~3.0 || ~4.0",
         "overtrue/phplint": "^9.0",
         "phpstan/phpstan": "^1.10 || ^2.0",

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -13,6 +13,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader;
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
 use Closure;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -129,8 +130,8 @@ class FormatterLoaderTest extends TestCase
      * @param  string $optionName Option name
      * @param  mixed $optionValue Option value
      * @param  string $calledMethodName Expected called method name
-     * @dataProvider handlerParamsProvider
      */
+    #[DataProvider('handlerParamsProvider')]
     public function testHandlers($class, $optionName, $optionValue, $calledMethodName)
     {
         // Test if handler exists and return it

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -17,6 +17,7 @@ use InvalidArgumentException;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Processor\MemoryUsageProcessor;
 use Monolog\Processor\WebProcessor;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -218,8 +219,8 @@ class HandlerLoaderTest extends TestCase
      * @param  string $optionName Option name
      * @param  mixed $optionValue Option value
      * @param  string $calledMethodName Expected called method name
-     * @dataProvider handlerParamsProvider
      */
+    #[DataProvider('handlerParamsProvider')]
     public function testHandlers($class, $optionName, $optionValue, $calledMethodName)
     {
         $options = array();

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 use Cascade\Util;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionParameter;
@@ -149,8 +150,8 @@ class ConstructorResolverTest extends TestCase
      * @param array $expectedResolvedOptions Array of expected resolved options
      * (i.e. parsed and validated)
      * @param  array $options Array of raw options
-     * @dataProvider optionsProvider
      */
+    #[DataProvider('optionsProvider')]
     public function testResolve(array $expectedResolvedOptions, array $options)
     {
         $this->assertEquals($expectedResolvedOptions, $this->resolver->resolve($options));
@@ -167,17 +168,14 @@ class ConstructorResolverTest extends TestCase
     public static function missingOptionsProvider()
     {
         return array(
-            array(
-                array( // No values
-                ),
-                array( // Missing a mandatory value
-                    'optionalB' => 'BBB'
-                ),
-                array( // Still missing a mandatory value
-                    'optionalB' => 'there',
-                    'optionalA' => 'hello'
-                )
-            )
+            array(array()), // No values
+            array(array( // Missing a mandatory value
+                'optionalB' => 'BBB'
+            )),
+            array(array( // Still missing a mandatory value
+                'optionalB' => 'there',
+                'optionalA' => 'hello'
+            ))
         );
     }
 
@@ -185,8 +183,8 @@ class ConstructorResolverTest extends TestCase
      * Test resolving with missing/incomplete options. It should throw an exception.
      *
      * @param  array $incompleteOptions Array of invalid options
-     * @dataProvider missingOptionsProvider
      */
+    #[DataProvider('missingOptionsProvider')]
     public function testResolveWithMissingOptions(array $incompleteOptions)
     {
         $this->expectException(Symfony\Component\OptionsResolver\Exception\MissingOptionsException::class);
@@ -204,19 +202,17 @@ class ConstructorResolverTest extends TestCase
     public static function invalidOptionsProvider()
     {
         return array(
-            array(
-                array('ABC'),
-                array( // All invalid
-                    'someInvalidOptionA' => 'abc',
-                    'someInvalidOptionB' => 'def'
-                ),
-                array( // Some invalid
-                    'optionalB' => 'there',
-                    'optionalA' => 'hello',
-                    'mandatory' => 'dsadsa',
-                    'additionalInvalid' => 'some unknow param'
-                )
-            )
+            array(array('ABC')),
+            array(array( // All invalid
+                'someInvalidOptionA' => 'abc',
+                'someInvalidOptionB' => 'def'
+            )),
+            array(array( // Some invalid
+                'optionalB' => 'there',
+                'optionalA' => 'hello',
+                'mandatory' => 'dsadsa',
+                'additionalInvalid' => 'some unknow param'
+            ))
         );
     }
 
@@ -224,8 +220,8 @@ class ConstructorResolverTest extends TestCase
      * Test resolving with invalid options. It should throw an exception.
      *
      * @param  array $invalidOptions Array of invalid options
-     * @dataProvider invalidOptionsProvider
      */
+    #[DataProvider('invalidOptionsProvider')]
     public function testResolveWithInvalidOptions($invalidOptions)
     {
         $this->expectException(Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException::class);

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -11,6 +11,7 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symfony;
@@ -152,17 +153,15 @@ class ExtraOptionsResolverTest extends TestCase
     public static function invalidOptionsProvider()
     {
         return array(
-            array(
-                array( // Some invalid
-                    'optionalB' => 'there',
-                    'optionalA' => 'hello',
-                    'additionalInvalid' => 'some unknow param'
-                ),
-                array( // All invalid
-                    'someInvalidOptionA' => 'abc',
-                    'someInvalidOptionB' => 'def'
-                )
-            )
+            array(array( // Some invalid
+                'optionalB' => 'there',
+                'optionalA' => 'hello',
+                'additionalInvalid' => 'some unknow param'
+            )),
+            array(array( // All invalid
+                'someInvalidOptionA' => 'abc',
+                'someInvalidOptionB' => 'def'
+            ))
         );
     }
 
@@ -170,8 +169,8 @@ class ExtraOptionsResolverTest extends TestCase
      * Test resolving with invalid options. It should throw an exception.
      *
      * @param  array $invalidOptions Array of invalid options
-     * @dataProvider invalidOptionsProvider
      */
+    #[DataProvider('invalidOptionsProvider')]
     public function testResolveWithInvalidOptions($invalidOptions)
     {
         $this->expectException(Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException::class);

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -13,6 +13,7 @@ namespace Cascade\Tests\Config\Loader;
 use Cascade\Config\Loader\ClassLoader;
 use Cascade\Tests\Fixtures\DependentClass;
 use Cascade\Tests\Fixtures\SampleClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -68,8 +69,8 @@ class ClassLoaderTest extends TestCase
      *
      * @param  array $options Array of options
      * @param  string $expectedClass Expected classname of the instantiated object
-     * @dataProvider dataFortestSetClass
      */
+    #[DataProvider('dataFortestSetClass')]
     public function testSetClass($options, $expectedClass)
     {
         $loader = new ClassLoader($options);

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -10,9 +10,10 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
+use Cascade\Config\Loader\FileLoader\FileLoaderAbstract;
 use Cascade\Tests\Fixtures;
 use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -24,8 +25,8 @@ use RuntimeException;
 class FileLoaderAbstractTest extends TestCase
 {
     /**
-     * Mock of extending Cascade\Config\Loader\FileLoader\FileLoaderAbstract
-     * @var MockObject
+     * Concrete subclass of Cascade\Config\Loader\FileLoader\FileLoaderAbstract
+     * @var FileLoaderAbstract
      */
     protected $mock = null;
 
@@ -37,10 +38,17 @@ class FileLoaderAbstractTest extends TestCase
             'Symfony\Component\Config\FileLocatorInterface'
         );
 
-        $this->mock = $this->getMockForAbstractClass(
-            'Cascade\Config\Loader\FileLoader\FileLoaderAbstract',
-            array($fileLocatorMock)
-        );
+        $this->mock = new class ($fileLocatorMock) extends FileLoaderAbstract {
+            public function load(mixed $resource, ?string $type = null): mixed
+            {
+                return null;
+            }
+
+            public function supports(mixed $resource, ?string $type = null): bool
+            {
+                return false;
+            }
+        };
 
         // Setting valid extensions for tests
         $mockClass = get_class($this->mock);
@@ -96,8 +104,8 @@ class FileLoaderAbstractTest extends TestCase
      *
      * @param boolean $expected Expected boolean value
      * @param string $filepath Filepath to validate
-     * @dataProvider extensionsDataProvider
      */
+    #[DataProvider('extensionsDataProvider')]
     public function testValidateExtension($expected, $filepath)
     {
         if ($expected) {
@@ -142,8 +150,8 @@ class FileLoaderAbstractTest extends TestCase
      * @param array $array Array of options
      * @param string $section Section key
      * @param array $expected Expected array for the given section
-     * @dataProvider arrayDataProvider
      */
+    #[DataProvider('arrayDataProvider')]
     public function testGetSectionOf(array $array, $section, array $expected)
     {
         $this->assertSame($expected, $this->mock->getSectionOf($array, $section));

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -11,8 +11,9 @@
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockBuilder;
 use stdClass;
 
 /**
@@ -24,7 +25,7 @@ class JsonTest extends TestCase
 {
     /**
      * JSON loader mock builder
-     * @var PHPUnit_Framework_MockObject_MockBuilder
+     * @var MockBuilder
      */
     protected $jsonLoader = null;
 
@@ -90,8 +91,8 @@ class JsonTest extends TestCase
      * Test loading resources supported by the JsonLoader
      *
      * @param mixed $invalidResource Invalid resource value
-     * @dataProvider notStringDataProvider
      */
+    #[DataProvider('notStringDataProvider')]
     public function testSupportsWithInvalidResource($invalidResource)
     {
         $this->assertFalse($this->jsonLoader->supports($invalidResource));

--- a/tests/Config/Loader/FileLoader/YamlTest.php
+++ b/tests/Config/Loader/FileLoader/YamlTest.php
@@ -11,8 +11,9 @@
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockBuilder;
 use stdClass;
 use Symfony\Component\Yaml\Yaml as YamlParser;
 
@@ -25,7 +26,7 @@ class YamlTest extends TestCase
 {
     /**
      * Yaml loader mock builder
-     * @var PHPUnit_Framework_MockObject_MockBuilder
+     * @var MockBuilder
      */
     protected $yamlLoader = null;
 
@@ -92,8 +93,8 @@ class YamlTest extends TestCase
      * Test loading resources supported by the YamlLoader
      *
      * @param mixed $invalidResource Invalid resource value
-     * @dataProvider notStringDataProvider
      */
+    #[DataProvider('notStringDataProvider')]
     public function testSupportsWithInvalidResource($invalidResource)
     {
         $this->assertFalse($this->yamlLoader->supports($invalidResource));

--- a/tests/Config/Loader/PhpArrayTest.php
+++ b/tests/Config/Loader/PhpArrayTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests\Config\Loader;
 
 use Cascade\Config\Loader\PhpArray as ArrayLoader;
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -73,8 +74,8 @@ class PhpArrayTest extends TestCase
      * Test loading resources supported by the YamlLoader
      *
      * @param mixed $invalidResource Invalid resource value
-     * @dataProvider notStringDataProvider
      */
+    #[DataProvider('notStringDataProvider')]
     public function testSupportsWithInvalidResource($invalidResource)
     {
         $this->assertFalse($this->arrayLoader->supports($invalidResource));


### PR DESCRIPTION
## Summary
- Widen `phpunit/phpunit` constraint from `^10.0` to `^10.0 || ^11.0 || ^12.0`.
- Migrate `@dataProvider` doc-comment metadata to `#[DataProvider]` attributes (removed in PHPUnit 12).
- Replace `getMockForAbstractClass()` (removed in PHPUnit 12) in `FileLoaderAbstractTest` with an anonymous concrete subclass — the test only exercised real methods, no mock instrumentation needed.
- Fix three data providers (`ConstructorResolverTest::missingOptionsProvider` / `invalidOptionsProvider`, `ExtraOptionsResolverTest::invalidOptionsProvider`) whose datasets were wrapped in an extra outer array. PHPUnit ≤10 silently dropped the extra arms; ≥11 emits a warning. Flattening makes the originally intended dataset arms run.

## Test plan
- [x] `composer install` resolves `phpunit/phpunit 12.5.24` on PHP 8.4.
- [x] `vendor/bin/phpunit tests/` → **102 passed, 147 assertions, 0 warnings** (was 97 before the data-provider fix).
- [x] CI runs the same matrix and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)