### PR TITLE
ci: test against PHP 8.5

### DIFF
--- a/.github/workflows/pr_phpunit.yml
+++ b/.github/workflows/pr_phpunit.yml
@@ -6,6 +6,7 @@ on:
       - '**/*.php'
       - '**/composer.lock'
       - '**/composer.json'
+      - '.github/workflows/pr_phpunit.yml'
 
 jobs:
   php_tests:

--- a/.github/workflows/pr_phpunit.yml
+++ b/.github/workflows/pr_phpunit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.4 ]
+        php-version: [ 8.4, 8.5 ]
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: shivammathur/setup-php@2.36.0


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the PHPUnit CI matrix alongside 8.4.

## Test plan
- [x] CI passes on PHP 8.4
- [x] CI passes on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)